### PR TITLE
security: Use POST instead of GET for sendSMS to protect credentials

### DIFF
--- a/custom_components/voipms_sms/__init__.py
+++ b/custom_components/voipms_sms/__init__.py
@@ -45,7 +45,7 @@ async def send_sms(hass, user, password, sender_did, call):
         _LOGGER.error("Recipient or message missing.")
         return
 
-    params = {
+    data = {
         "api_username": user,
         "api_password": password,
         "did": sender_did,
@@ -55,7 +55,7 @@ async def send_sms(hass, user, password, sender_did, call):
     }
 
     async with aiohttp.ClientSession() as session:
-        async with session.get(REST_ENDPOINT, params=params) as response:
+        async with session.post(REST_ENDPOINT, data=data) as response:
             result = await response.text()
             if response.status == 200:
                 _LOGGER.info("voipms_sms: SMS sent successfully: %s", result)


### PR DESCRIPTION
Change sendSMS from GET to POST request to prevent API credentials
from being exposed in URL query strings. Credentials in GET requests
are logged by web servers, proxies, etc, creating a security vulnerability.

VoIP.ms API supports both GET and POST methods. Using POST with
form data (application/x-www-form-urlencoded) keeps credentials in
the request body where they belong.

This is a drop-in replacement with no changes required.

The multipart form-data method was tested working.
